### PR TITLE
Add navigation functionality: address-based routing, map centers on user location

### DIFF
--- a/slope-spotter/package-lock.json
+++ b/slope-spotter/package-lock.json
@@ -18,6 +18,7 @@
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.5.0",
         "react-scripts": "5.0.1",
+        "slope-spotter": "file:",
         "web-vitals": "^2.1.4"
       }
     },
@@ -14175,6 +14176,10 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/slope-spotter": {
+      "resolved": "",
+      "link": true
     },
     "node_modules/sockjs": {
       "version": "0.3.24",

--- a/slope-spotter/package.json
+++ b/slope-spotter/package.json
@@ -13,6 +13,7 @@
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.5.0",
     "react-scripts": "5.0.1",
+    "slope-spotter": "file:",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/slope-spotter/src/Navigation.js
+++ b/slope-spotter/src/Navigation.js
@@ -1,4 +1,6 @@
 import "./App.css";
+import mapboxgl from 'mapbox-gl';
+import React, { use, useRef, useState, useEffect } from 'react';
 
 import BottomNav from './components/BottomNav/BottomNav';
 import SpeechButton from './components/SpeechText/SpeechButton.js';
@@ -9,33 +11,103 @@ import { useNavigate } from 'react-router-dom';
 
 function Navigation() {
   const navigate = useNavigate();
+  const mapRef = useRef();
+  const [startAddr, setStartAddr] = useState('');
+  const [endAddr, setEndAddr] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [userLocation, setUserLocation] = useState(null);
 
   const handleTranscript = (text) => {
     console.log('🗣️ Transcript:', text);
     // Here you can handle the transcript, e.g., send it to your backend or process it further
   };
 
+  useEffect(() => {
+    if (!navigator.geolocation) { return; }
+    navigator.geolocation.getCurrentPosition(
+      ({ coords }) => {
+        setUserLocation([coords.longitude, coords.latitude]);
+      },
+      err => {
+        console.warn("Geolocation failed:", err);
+      }
+    );
+  }, []);
+  const handleStart = async () => {
+    if (!endAddr.trim()) {
+      alert("Please enter a destination");
+      return;
+    }
+    setLoading(true);
+    try {
+      // use user location if startAddr is empty
+      const startCoords = startAddr.trim()
+        ? await geocode(startAddr)
+        : userLocation ?? (() => { throw new Error("Please enter start address"); })();
+      const endCoords = await geocode(endAddr);
+      mapRef.current?.getRoute(startCoords, endCoords);
+    } catch (err) {
+      alert(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleStop = () => mapRef.current?.stopRoute();
+
   return (
     <div className="App">
       <div className="container">
-        <Header title="Navigation"/>
+        <Header title="Navigation" />
         <div className="input-section">
-          <input type="text" placeholder="Start" />
-          <input type="text" placeholder="End" />
-        </div> 
+          <input
+            type="text"
+            placeholder="Your Location"
+            value={startAddr}
+            onChange={e => setStartAddr(e.target.value)}
+          />
+          <input
+            type="text"
+            placeholder="Enter Destination"
+            value={endAddr}
+            onChange={e => setEndAddr(e.target.value)}
+          />
+        </div>
+        {/* TODO: I put a temporary button here to start navigation, feel free to change style */}
+        <div className="button-section">
+          <button onClick={handleStart} disabled={loading || (!startAddr.trim() && userLocation === null)}>
+            {loading ? 'Loading...' : 'Start Navigation'}
+          </button>
+          <button className="nav-button" onClick={handleStop}>
+            Stop Navigation
+          </button>
+        </div>
+
         {/* TODO: speech to text button */}
         <SpeechButton onTranscript={handleTranscript} />
         {/* TODO: mapbox map */}
         <div style={{ width: '100%', height: '400px', margin: '1rem 0' }}>
-          <MapBox/>
+          <MapBox ref={mapRef} />
         </div>
-        
+
         {/* TODO: elevation viewer */}
         {/* TODO: remaining miles, time info at the bottom */}
       </div>
       <BottomNav />
     </div>
   );
+}
+
+async function geocode(address) {
+  console.log('geocode', address);
+  const encoded = encodeURIComponent(address);
+  const res = await fetch(
+    `https://api.mapbox.com/geocoding/v5/mapbox.places/` +
+    `${encoded}.json?access_token=${mapboxgl.accessToken}&limit=1`
+  );
+  const json = await res.json();
+  if (!json.features?.length) throw new Error("Cannot find location");
+  return json.features[0].center;
 }
 
 export default Navigation;

--- a/slope-spotter/src/components/MapBox/MapBox.js
+++ b/slope-spotter/src/components/MapBox/MapBox.js
@@ -1,59 +1,106 @@
-import React, { useRef, useEffect, useState } from 'react';
+// src/components/MapBox/MapBox.js
+import React, {
+  forwardRef,
+  useRef,
+  useEffect,
+  useState,
+  useImperativeHandle,
+} from 'react';
 import mapboxgl from 'mapbox-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
 
 mapboxgl.accessToken = process.env.REACT_APP_MAPBOX_TOKEN;
 
-const MapBox = ({
-  zoom   = 14,
-  style  = 'mapbox://styles/mapbox/streets-v11',
-  height = '400px',
-}) => {
+const MapBox = forwardRef(({ zoom = 14, style, height='400px' }, ref) => {
   const mapRef = useRef(null);
   const containerRef = useRef();
   const [center, setCenter] = useState([-122.2585, 37.8719]);
 
-  // default center is Berkeley, CA, stored in a ref
-  const initialCenterRef = useRef(center);
-
   // 1) ask for user location
   useEffect(() => {
-    if (!navigator.geolocation) return;
-    navigator.geolocation.getCurrentPosition(
+    navigator.geolocation?.getCurrentPosition(
       ({ coords }) => setCenter([coords.longitude, coords.latitude]),
-      err => console.warn('Geolocation failed:', err)
+      () => {}  // ignore
     );
   }, []);
 
-  // 2) initialize map
+  // 2) init map
   useEffect(() => {
     const map = new mapboxgl.Map({
       container: containerRef.current,
-      style,
-      center: initialCenterRef.current,
+      style: style || 'mapbox://styles/mapbox/streets-v11',
+      center,
       zoom,
     });
-    mapRef.current = map;
 
-    return () => {
-      map.remove();
-      mapRef.current = null;
-    };
+    // prepare an empty geojson source for the route
+    map.on('load', () => {
+      map.addSource('route', {
+        type: 'geojson',
+        data: { type: 'FeatureCollection', features: [] },
+      });
+    });
+
+    mapRef.current = map;
+    return () => map.remove();
   }, [style, zoom]);
 
-  // change center on user location
+  // 3) pan when center changes
   useEffect(() => {
-    if (mapRef.current) {
-      mapRef.current.easeTo({ center, duration: 1000 });
-    }
+    mapRef.current?.easeTo({ center, duration: 1000 });
   }, [center]);
 
-  return (
-    <div
-      ref={containerRef}
-      style={{ width: '100%', height }}
-    />
-  );
-};
+  // 4) expose imperative methods
+  useImperativeHandle(ref, () => ({
+    async getRoute(start, end) {
+      console.log('getRoute', start, end);
+      const map = mapRef.current;
+      if (!map) return;
+
+      const res = await fetch(
+        `https://api.mapbox.com/directions/v5/mapbox/cycling/` +
+        `${start[0]},${start[1]};${end[0]},${end[1]}` +
+        `?steps=true&geometries=geojson&access_token=${mapboxgl.accessToken}`
+      );
+      const json = await res.json();
+      const data = json.routes?.[0]?.geometry;
+      if (!data) return;
+
+      const geojson = { type: 'Feature', properties: {}, geometry: data };
+
+      map.getSource('route').setData(geojson);
+
+      if (!map.getLayer('route-line')) {
+        map.addLayer({
+          id: 'route-line',
+          type: 'line',
+          source: 'route',
+          layout: { 'line-join': 'round', 'line-cap': 'round' },
+          paint: {
+            'line-color': '#3887be',
+            'line-width': 5,
+            'line-opacity': 0.75,
+          },
+        });
+      }
+    },
+
+    stopRoute() {
+      console.log('stopRoute');
+      const map = mapRef.current;
+      if (!map) return;
+      if (map.getLayer('route-line')) map.removeLayer('route-line');
+      if (map.getSource('route')) {
+        map.removeSource('route');
+        map.addSource('route', {
+          type: 'geojson',
+          data: { type: 'FeatureCollection', features: [] },
+        });
+      }
+    },
+  }));
+
+  return <div ref={containerRef} style={{ width: '100%', height }} />;
+});
 
 export default MapBox;


### PR DESCRIPTION
This PR adds navigation features to the map page:

Center the map on the user's current location when available.
Display cycling routes on the map based on user input addresses. (We can consider adding a button to switch between walking, driving, or public transit routes in the future.)
Geocode start and end addresses using the Mapbox Geocoding API.
If the start address is left blank, automatically use the user's current location as the starting point.
Provide buttons to start and stop navigation.