### PR TITLE
Inline Speech Button & Address Autofill with speech (ref #23)

### DIFF
--- a/slope-spotter/src/App.css
+++ b/slope-spotter/src/App.css
@@ -109,6 +109,21 @@ button:hover {
   pointer-events: none;
 }
 
+.button-section {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.button-section button {
+  flex-shrink: 0;
+}
+
+.speech-btn {
+  width: 2.5rem;
+  height: 2.5rem;
+}
+
 /* INPUT FIELDS */
 input, select {
   font-family: "Inter", "Sans Serif", sans-serif;

--- a/slope-spotter/src/Navigation.js
+++ b/slope-spotter/src/Navigation.js
@@ -15,9 +15,32 @@ function Navigation() {
   const [loading, setLoading] = useState(false);
   const [userLocation, setUserLocation] = useState(null);
 
-  const handleTranscript = (text) => {
-    console.log('🗣️ Transcript:', text);
-    // Here you can handle the transcript, e.g., send it to your backend or process it further
+  const handleTranscript = async (text) => {
+    // console.log('🗣️ Transcript:', text);
+    try {
+      const url = `https://noggin.rea.gent/quickest-cat-9424`
+        + `?key=rg_v1_9n82jzc2cl821cr8t6n77pmg4cilsx5dcfmy_ngk`
+        + `&request=${encodeURIComponent(text)}`;
+  
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`Reagent error:${res.status}`);
+      const addresses = await res.json();
+      // expect Reagent a list of addresses
+      if (Array.isArray(addresses) && addresses.length >= 2) {
+        const [origin, destination] = addresses;
+        if (origin.trim().toLowerCase() === '') {
+          setStartAddr('');
+        } else {
+          setStartAddr(origin);
+        }
+        setEndAddr(destination);
+      } else {
+        throw new Error('Wrong response from Reagent');
+      }
+    } catch (err) {
+      console.error(err);
+      alert('Error getting address from Speech, please try to be more specific or use text input');
+    }
   };
 
   useEffect(() => {
@@ -92,7 +115,7 @@ function Navigation() {
 }
 
 async function geocode(address) {
-  console.log('geocode', address);
+  // console.log('geocode', address);
   const encoded = encodeURIComponent(address);
   const res = await fetch(
     `https://api.mapbox.com/geocoding/v5/mapbox.places/` +
@@ -100,6 +123,7 @@ async function geocode(address) {
   );
   const json = await res.json();
   if (!json.features?.length) throw new Error("Cannot find location");
+  // console.log('geocode result', json.features[0].center);
   return json.features[0].center;
 }
 

--- a/slope-spotter/src/Navigation.js
+++ b/slope-spotter/src/Navigation.js
@@ -78,9 +78,9 @@ function Navigation() {
           <button className="nav-button" onClick={handleStop}>
             Stop Navigation
           </button>
+          <SpeechButton onTranscript={handleTranscript} />
         </div>
 
-        <SpeechButton onTranscript={handleTranscript} />
         <div style={{ width: '100%', height: '300px', margin: '1rem 0' }}>
           <MapBox ref={mapRef} />
         </div>


### PR DESCRIPTION
- **UI Update**: Moved the speech‑to‑text button inline with the Start/Stop navigation controls.  
- **Functionality**: Implemented `handleTranscript` to call our Reagent noggin endpoint and autofill the origin/destination inputs (falls back to `""`).  

---

### Noggin Prompt
```text
The user will speak a navigation request $request mentioning one or two Berkeley landmarks or addresses. Your job is to:

1. Identify the origin and destination.
2. Look up each as a full street address in Berkeley, CA (including ZIP).
3. If no origin is given, use "" as the origin.
4. Return exactly two strings in a JSON array:
   [ "origin_address", "destination_address" ]

Example 1:
Input: "Show me the route from Doe Library to RSF"
Output:
[
  "Doe Library, Campanile Way, Berkeley, CA 94720",
  "2301 Bancroft Way, Berkeley, CA 94720"
]

Example 2:
Input: "Take me from rsf to Lawrence lab"
Output:
[
  "2301 Bancroft Way, Berkeley, CA 94720",
  "Lawrence Berkeley National Laboratory, 1 Cyclotron Rd, Berkeley, CA 94720"
]
